### PR TITLE
Feature/ruby stuffs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/vendor/
+Gemfile.lock
+/.yardoc/
+/doc/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,69 @@
+---
+AllCops:
+  Exclude:
+    - '**/vendor/**/*'
+    - '**/spec/fixtures/**/*'
+
+
+### MODULE SYNC SYNC
+
+# Method length is not necessarily an indicator of code quality
+Metrics/MethodLength:
+  Enabled: False
+
+# Module length is not necessarily an indicator of code quality
+Metrics/ModuleLength:
+  Enabled: False
+
+# Class length is not necessarily an indicator of code quality
+Metrics/ClassLength:
+  Enabled: False
+
+# 'Complexity' is very relative
+Metrics/CyclomaticComplexity:
+  Enabled: False
+
+Style/Documentation:
+  Enabled: False
+
+Style/DotPosition:
+  EnforcedStyle: trailing
+
+# Configuration parameters: AllowURI, URISchemes.
+Metrics/LineLength:
+  Enabled: False
+
+# based on https://github.com/voxpupuli/modulesync_config/issues/168
+Style/RegexpLiteral:
+  EnforcedStyle: percent_r
+  Enabled: True
+
+Metrics/ParameterLists:
+  Enabled: False
+
+# 'Complexity' is very relative
+Metrics/AbcSize:
+  Enabled: False
+
+# 'Complexity' is very relative
+Metrics/PerceivedComplexity:
+  Enabled: False
+
+Style/ClosingParenthesisIndentation:
+  Enabled: False
+
+# RSpec
+# Allow us to nest rspec tests.
+RSpec/NestedGroups:
+  Max: 3
+
+# We don't use rspec in this way
+RSpec/DescribeClass:
+  Enabled: False
+
+# Example length is not necessarily an indicator of code quality
+RSpec/ExampleLength:
+  Enabled: False
+
+RSpec/NamedSubject:
+  Enabled: False

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,58 @@
+source 'https://rubygems.org'
+
+def location_from_env(env, default_location = [])
+  if ENV[env]
+    location = ENV[env]
+    if location =~ %r{^(?<git_location>(?:git|https?)[:@][^#]*)#(?<git_branch>.*)}
+      [{ git: git_location, branch: git_branch, require: false }]
+    elsif location =~ %r{^file://(?<filename>.*)}
+      ['>= 0', { path: File.expand_path(filename), require: false }]
+    else
+      [location, { require: false }]
+    end
+  else
+    default_location
+  end
+end
+
+gem 'puppet', *location_from_env('PUPPET_GEM_VERSION')
+
+group :eyaml do
+  gem 'gpgme'
+  gem 'hiera-eyaml'
+  gem 'hiera-eyaml-gpg'
+end
+
+group :development do
+  gem 'awesome_print'
+end
+
+group :test do
+  gem 'puppet-lint', '!= 2.3.2'
+  gem 'puppet-lint-classes_and_types_beginning_with_digits-check'
+  gem 'puppet-lint-file_ensure-check'
+  # gem 'puppet-lint-global_resource-check'
+  gem 'puppet-lint-leading_zero-check'
+  gem 'puppet-lint-param-docs', '>= 1.4.0'
+  # gem 'puppet-lint-resource_outside_class-check'
+  gem 'puppet-lint-trailing_comma-check'
+  gem 'puppet-lint-unquoted_string-check'
+  gem 'puppet-lint-variable_contains_upcase'
+  gem 'puppet-lint-version_comparison-check'
+  # gem 'puppet-lint-package_ensure-check'
+  # gem 'puppet-lint-numericvariable'
+  gem 'json_pure', '<=2.0.1', require: false if RUBY_VERSION =~ %r{^1\.}
+  gem 'puppet-syntax'
+  gem 'puppet_rake_tasks', '~> 1.0.0'
+  gem 'puppetlabs_spec_helper'
+  gem 'rspec'
+  gem 'rubocop', '~> 0.48.1'
+  gem 'rubocop-checkstyle_formatter', require: false
+  gem 'rubocop-rspec'
+end
+
+group :doc do
+  gem 'puppet-strings', '~> 1.0.0'
+  gem 'rdoc'
+  gem 'redcarpet'
+end

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,61 @@
+# Rakefile
+require 'rubygems'
+require_relative 'rake_tasks/support'
+
+PUPPET_INCLUDE_DOCUMENTATION = %w[
+  modules
+  manifests
+].freeze
+
+# Leave this commented to use the default puppetstrings patterns with some
+# magic sprinkled on top (see rake_tasks/documentation.rb)
+# PUPPET_INCLUDE_DOCUMENTATION_EXPANDS = [
+#   '%s/**/manifests/**/*.pp',
+#   '%s/**/lib/**/*.rb'
+# ].freeze
+
+PUPPET_EXCLUDE_DOCUMENTATION = [
+  '/vendor/',
+  '/spec/'
+].freeze
+
+PUPPET_EXCLUDE_PATHS = [
+  # 'modules/upstream/**/*',
+  # 'modules/<company>/**/*',
+  'vendor/**/*',
+  '**/vendor/**/*',
+  '**/spec/**/*'
+].freeze
+
+PUPPET_DEPENDENCY_CONFIG = File.join(File.dirname(__FILE__), '.puppet_dependency_ignores.yaml')
+
+HIERA_INCLUDE_PATHS = [
+  'hieradata/**/*.yaml'
+].freeze
+
+RUBY_INCLUDE_PATHS = [
+  'Rakefile',
+  'Gemfile',
+  'rake_tasks/*.rb',
+  # Add more 'module' paths wich contain ruby here
+].freeze
+
+JENKINS_TASKS = [
+  'syntax',
+  'jenkins:lint',
+  'jenkins:rubocop',
+  'documentation'
+].freeze
+
+require_relative 'rake_tasks/spec' # required for puppet-syntax and puppet-lint
+require_relative 'rake_tasks/puppet_syntax'
+require_relative 'rake_tasks/rubocop'
+require_relative 'rake_tasks/puppet_lint'
+require_relative 'rake_tasks/documentation'
+require_relative 'rake_tasks/jenkins'
+require_relative 'rake_tasks/module_depcheck'
+
+Rake::Task['default'].clear
+DEFAULT_TASKS = %i[syntax lint rubocop depcheck].freeze
+desc "Runs default task (#{DEFAULT_TASKS.join(', ')})"
+task default: DEFAULT_TASKS

--- a/rake_tasks/documentation.rb
+++ b/rake_tasks/documentation.rb
@@ -1,0 +1,22 @@
+require_relative 'support'
+require 'puppet-strings'
+
+PUPPET_INCLUDE_DOCUMENTATION_EXPANDS ||= PuppetStrings::DEFAULT_SEARCH_PATTERNS.map { |s| "%s/**/#{s}" }.freeze
+
+desc 'Generate Puppet documentation with YARD excluding upstream modules'
+task :documentation do |_t|
+  exclude_args = PUPPET_EXCLUDE_DOCUMENTATION.map { |x| ['--exclude', x] }.flatten
+  include_args = PUPPET_INCLUDE_DOCUMENTATION.product(PUPPET_INCLUDE_DOCUMENTATION_EXPANDS).collect do |incl, expand|
+    format(expand, incl)
+  end
+  PuppetStrings.generate(include_args, yard_args: exclude_args)
+end
+
+desc 'Generate Puppet documentation with YARD including upstream modules'
+task 'documentation:all' do |_t|
+  exclude_args = PUPPET_EXCLUDE_DOCUMENTATION.map { |x| ['--exclude', x] }.flatten
+  include_args = %w[site modules].product(PUPPET_INCLUDE_DOCUMENTATION_EXPANDS).collect do |incl, expand|
+    format(expand, incl)
+  end
+  PuppetStrings.generate(include_args, yard_args: exclude_args)
+end

--- a/rake_tasks/jenkins.rb
+++ b/rake_tasks/jenkins.rb
@@ -1,0 +1,17 @@
+namespace :jenkins do
+  task :all do
+    base = ENV['BUNDLE_GEMFILE'].nil? ? 'rake' : "#{ENV['BUNDLE_BIN_PATH']} exec rake"
+    failed_tasks = []
+    JENKINS_TASKS.each do |target|
+      # puts "Executing '#{base} #{target}'"
+      failed_tasks << target unless system("#{base} #{target}")
+    end
+    unless failed_tasks.empty?
+      warn "The following targets failed: #{failed_tasks.join(', ')}"
+      exit(1)
+    end
+  end
+end
+
+desc "Run all jenkins tasks (#{JENKINS_TASKS.join(', ')})"
+task jenkins: ['jenkins:all']

--- a/rake_tasks/module_depcheck.rb
+++ b/rake_tasks/module_depcheck.rb
@@ -1,0 +1,11 @@
+require 'puppet_rake_tasks/depchecker'
+
+PuppetRakeTasks::DepChecker::Task.new do |checker|
+  checker.fail_on_error = true
+  checker.modulepath = [
+    'site',
+    'modules/vrt',
+    'modules/upstream'
+  ]
+  checker.ignores = YAML.load_file(PUPPET_DEPENDENCY_CONFIG) if PUPPET_DEPENDENCY_CONFIG
+end

--- a/rake_tasks/puppet_lint.rb
+++ b/rake_tasks/puppet_lint.rb
@@ -1,0 +1,26 @@
+require 'puppet-lint'
+
+# workaround for https://github.com/rodjek/puppet-lint/issues/355
+Rake::Task[:lint].clear
+PuppetLint::RakeTask.new :lint do |config|
+  config.fail_on_warnings = false
+  config.ignore_paths = PUPPET_EXCLUDE_PATHS
+  config.fix = true
+end
+Rake::Task['lint'].comment = 'fix (supported) issues'
+
+PuppetLint::RakeTask.new 'lint:no_fix' do |config|
+  config.fail_on_warnings = false
+  config.ignore_paths = PUPPET_EXCLUDE_PATHS
+  config.fix = false
+end
+Rake::Task['lint:no_fix'].comment = 'Do not execute any automatic fixes'
+
+desc 'Run puppet-lint (for jenkins)'
+PuppetLint::RakeTask.new 'jenkins:lint' do |config|
+  config.fail_on_warnings = true
+  config.log_format = '%{path}:%{line}:%{check}:%{KIND}:%{message}'
+  config.ignore_paths = PUPPET_EXCLUDE_PATHS
+  config.fix = false
+end
+Rake::Task['jenkins:lint'].comment = 'No fixing, Fails on warnings'

--- a/rake_tasks/puppet_syntax.rb
+++ b/rake_tasks/puppet_syntax.rb
@@ -1,0 +1,6 @@
+require 'puppet-syntax/tasks/puppet-syntax'
+
+PuppetSyntax.future_parser = true unless Puppet::PUPPETVERSION.to_i >= 4
+
+PuppetSyntax.hieradata_paths = HIERA_INCLUDE_PATHS
+PuppetSyntax.exclude_paths = PUPPET_EXCLUDE_PATHS

--- a/rake_tasks/rubocop.rb
+++ b/rake_tasks/rubocop.rb
@@ -1,0 +1,32 @@
+require 'rubocop/rake_task'
+# see https://github.com/eitoball/rubocop-checkstyle_formatter/pull/11
+require 'rubocop/formatter/base_formatter'
+require 'rubocop/formatter/checkstyle_formatter'
+require 'rubocop-rspec'
+
+Rake::Task['rubocop'].clear
+RuboCop::RakeTask.new(:rubocop) do |task|
+  task.patterns = RUBY_INCLUDE_PATHS
+  task.formatters = %w[fuubar offenses]
+  task.fail_on_error = false
+  task.options = [
+    '--config', '.rubocop.yml',
+    '--force-exclusion'
+  ]
+end
+
+RuboCop::RakeTask.new('jenkins:rubocop') do |task|
+  task.patterns = RUBY_INCLUDE_PATHS
+  task.options = [
+    '--format', 'RuboCop::Formatter::CheckstyleFormatter', '--no-color', '--out', 'tmp/ruby-checkstyle.xml',
+    '--format', 'clang',
+    '--format', 'offenses',
+    '--config', '.rubocop.yml',
+    '--force-exclusion'
+  ]
+  task.fail_on_error = false
+end
+Rake::Task['jenkins:rubocop'].comment = 'No autocorrect / report to (checkstyle) xml'
+
+# Remove the auto correct task for jenkins. Not something we want to automate.
+Rake::Task['jenkins:rubocop:auto_correct'].clear

--- a/rake_tasks/spec.rb
+++ b/rake_tasks/spec.rb
@@ -1,0 +1,12 @@
+require 'puppetlabs_spec_helper/rake_tasks'
+
+## We only need the puppetlabs_spec_helper for other tasks to depend on. Clear all known tasks we are not using.
+%w[
+  beaker beaker:sets beaker:ssh
+  build clean
+  compute_dev_version
+  parallel_spec spec spec_clean spec_prep spec_standalone
+  release_checks check:dot_underscore check:git_ignore check:symlinks check:test_file
+].each do |t|
+  Rake::Task[t].clear
+end

--- a/rake_tasks/support.rb
+++ b/rake_tasks/support.rb
@@ -1,0 +1,10 @@
+# Monkey patch Kernel so we can use this everywhere
+module Kernel
+  def suppress_warnings
+    original_verbosity = $VERBOSE
+    $VERBOSE = nil
+    result = yield
+    $VERBOSE = original_verbosity
+    result
+  end
+end


### PR DESCRIPTION
Add automagic testing for 
* syntax
* style
* ruby code
* module dependencies

Add documentation generation (puppet strings)

```
$ bundle exec rake -T
rake default               # Runs default task (syntax, lint, rubocop, depcheck)
rake depcheck              # Check puppet module dependencies
rake documentation         # Generate Puppet documentation with YARD excluding upstream modules
rake documentation:all     # Generate Puppet documentation with YARD including upstream modules
rake help                  # Display the list of available rake tasks
rake jenkins               # Run all jenkins tasks (syntax, jenkins:lint, jenkins:rubocop, documentation)
rake jenkins:lint          # Run puppet-lint / No fixing, Fails on warnings
rake jenkins:rubocop       # Run RuboCop / No autocorrect / report to (checkstyle) xml
rake lint                  # Run puppet-lint / fix (supported) issues
rake lint:no_fix           # Run puppet-lint / Do not execute any automatic fixes
rake rubocop               # Run RuboCop
rake rubocop:auto_correct  # Auto-correct RuboCop offenses
rake spec_list_json        # List spec tests in a JSON document
rake syntax                # Syntax check Puppet manifests and templates
rake syntax:hiera          # Syntax check Hiera config files
rake syntax:manifests      # Syntax check Puppet manifests
rake syntax:templates      # Syntax check Puppet templates
rake validate              # Check syntax of Ruby files and call :syntax and :metadata_lint
```
